### PR TITLE
UIRS-33 Refresh the list after the configuration has been edited

### DIFF
--- a/src/RemoteStorageSettings.js
+++ b/src/RemoteStorageSettings.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import { Route, withRouter } from 'react-router';
+import { Route, Switch, withRouter } from 'react-router';
 
 import {
   Paneset,
@@ -8,34 +8,35 @@ import {
 import RemoteStoragesListContainer from './RemoteStoragesList';
 import RemoteStorageDetails from './RemoteStorageDetails';
 import RemoteStorageEditorContainer from './RemoteStorageEditor';
-import CreateRomoteStoargeContainer from './CreateRemoteStorage';
+import CreateRemoteStorageContainer from './CreateRemoteStorage';
 
 import { STORAGES_LIST_ROUTE } from './const';
 
 const RemoteStorageSettings = () => {
   return (
-    <>
-      <Paneset
-        paneTitle={<FormattedMessage id="ui-remote-storage.meta.title" />}
-      >
-        <Route
-          path={STORAGES_LIST_ROUTE}
-          component={RemoteStoragesListContainer}
-        />
-        <Route
-          path={`${STORAGES_LIST_ROUTE}/view/:id`}
-          component={RemoteStorageDetails}
-        />
-      </Paneset>
+    <Switch>
       <Route
+        exact
         path={`${STORAGES_LIST_ROUTE}/edit/:id`}
         component={RemoteStorageEditorContainer}
       />
       <Route
+        exact
         path={`${STORAGES_LIST_ROUTE}/create`}
-        component={CreateRomoteStoargeContainer}
+        component={CreateRemoteStorageContainer}
       />
-    </>
+      <Route path={STORAGES_LIST_ROUTE}>
+        <Paneset
+          paneTitle={<FormattedMessage id="ui-remote-storage.meta.title" />}
+        >
+          <RemoteStoragesListContainer />
+          <Route
+            path={`${STORAGES_LIST_ROUTE}/view/:id`}
+            component={RemoteStorageDetails}
+          />
+        </Paneset>
+      </Route>
+    </Switch>
   );
 };
 

--- a/src/RemoteStoragesList/RemoteStoragesListContainer.js
+++ b/src/RemoteStoragesList/RemoteStoragesListContainer.js
@@ -36,18 +36,15 @@ const RemoteStoragesListContainer = ({
   const loadConfigurations = useCallback(() => {
     setIsLoading(true);
     mutator.configurations.GET().then(({ totalRecords, configurations }) => {
-      setStoragesList(prev => [
-        ...prev,
-        ...configurations.map(storage => {
-          const lastUpdate = moment.utc(storage.metadata.updatedDate || storage.metadata.createdDate);
+      setStoragesList(configurations.map(storage => {
+        const lastUpdate = moment.utc(storage.metadata.updatedDate || storage.metadata.createdDate);
 
-          return {
-            ...storage,
-            providerName: intl.formatMessage({ id: `ui-remote-storage.name.${storage.providerName}` }),
-            lastUpdate: lastUpdate.format(localeDateFormat),
-          };
-        }),
-      ]);
+        return {
+          ...storage,
+          providerName: intl.formatMessage({ id: `ui-remote-storage.name.${storage.providerName}` }),
+          lastUpdate: lastUpdate.format(localeDateFormat),
+        };
+      }));
       setStoragesCount(totalRecords);
     }).finally(() => setIsLoading(false));
   // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Refresh the list after the configuration has been edited
https://issues.folio.org/browse/UIRS-33
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
After an existing configuration has been edited, changing the name or the provider, the changes are reflected in the View pane, but not the List pane.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
Changed the routing logic.
Either editor or list-and-view rendered.
So after the Editor closed, the list-and-view are re-rendered regardless.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
Add tests
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
