### PR TITLE
UIRS-109: Use Save & close button label stripes-component translation key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## (5.2.0 IN PROGRESS)
 
+* Use Save & close button label stripes-component translation key. Refs UIRS-109.
+
 ##[5.1.0](https://github.com/folio-org/ui-remote-storage/tree/v5.1.0) (2024-03-20)
 [Full Changelog](https://github.com/folio-org/ui-remote-storage/compare/v5.0.0...v5.1.0)
 

--- a/src/Configurations/EditorLayer/TheForm.js
+++ b/src/Configurations/EditorLayer/TheForm.js
@@ -14,7 +14,7 @@ const FormComponent = ({ pristine, submitting, onClose, handleSubmit, title, isL
 
   const paneFooter = useMemo(() => (
     <FormFooter
-      label={intl.formatMessage({ id: 'ui-remote-storage.saveAndClose' })}
+      label={intl.formatMessage({ id: 'stripes-components.saveAndClose' })}
       handleSubmit={handleSubmit}
       pristine={pristine}
       submitting={submitting}

--- a/translations/ui-remote-storage/en.json
+++ b/translations/ui-remote-storage/en.json
@@ -13,7 +13,6 @@
   "accession-tables.open": "Open Accession table",
 
   "edit": "Edit",
-  "saveAndClose": "Save & close",
   "delete": "Delete",
   "select": "Select",
   "loading": "Loading...",


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIRS-109
We removed local `saveAndClose` label and replace it with `stripes-components.saveAndClose`. Also all related tests updated